### PR TITLE
Fix bazel link

### DIFF
--- a/book/how-google-builds-web-frameworks.md
+++ b/book/how-google-builds-web-frameworks.md
@@ -211,6 +211,7 @@ output. You don’t need to make clean. You can therefore send your
 builds/tests to build servers and parallelize them.
 
 <img src="images/google-frameworks/1_sq_8UFpeBsxSIpBXpmWiSg.png" title="1_sq_8UFpeBsxSIpBXpmWiSg.png" width="446" height="284" alt="1 sq 8UFpeBsxSIpBXpmWiSg" />
+
 Google has spent years developing such a build tool. It was open sourced
 last year as [Bazel](https://bazel.build/).
 


### PR DESCRIPTION
Looks like the Bazel link in "How Google Build Web Frameworks" is not correcty processed because of the previous element.

![image](https://user-images.githubusercontent.com/994594/152431721-e92c8b93-e4cf-485d-b7db-055387cf8bfd.png)
